### PR TITLE
Add EMPTY to return an empty range

### DIFF
--- a/src/main/kotlin/me/moallemi/tools/daterange/date/DateRange.kt
+++ b/src/main/kotlin/me/moallemi/tools/daterange/date/DateRange.kt
@@ -27,4 +27,8 @@ class DateRange(
     override fun iterator(): Iterator<Date> = DateIterator(start, endInclusive, stepDays)
 
     infix fun step(days: Int) = DateRange(start, endInclusive, days)
+
+    companion object {
+        val EMPTY: DateRange = DateRange(Date(1), Date(0))
+    }
 }

--- a/src/main/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRange.kt
+++ b/src/main/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRange.kt
@@ -28,4 +28,8 @@ class LocalDateRange(
         LocalDateIterator(start, endInclusive, stepDays)
 
     infix fun step(days: Long) = LocalDateRange(start, endInclusive, days)
+
+    companion object {
+        val EMPTY: LocalDateRange = LocalDateRange(LocalDate.ofEpochDay(1), LocalDate.ofEpochDay(0))
+    }
 }

--- a/src/test/kotlin/me/moallemi/tools/daterange/date/DateRangeTest.kt
+++ b/src/test/kotlin/me/moallemi/tools/daterange/date/DateRangeTest.kt
@@ -18,6 +18,7 @@ package me.moallemi.tools.daterange.date
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
@@ -63,6 +64,15 @@ class DateRangeTest {
         val actual = (startDate..endDate step 2).map {
             simpleDateFormat.format(it)
         }
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testEmpty() {
+        val expected = listOf<Date>()
+
+        val actual = DateRange.EMPTY.toList()
 
         assertEquals(expected, actual)
     }

--- a/src/test/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRangeTest.kt
+++ b/src/test/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRangeTest.kt
@@ -63,4 +63,13 @@ class LocalDateRangeTest {
 
         assertEquals(true, actual)
     }
+
+    @Test
+    fun testEmpty() {
+        val expected = listOf<LocalDate>()
+
+        val actual = LocalDateRange.EMPTY.toList()
+
+        assertEquals(expected, actual)
+    }
 }


### PR DESCRIPTION
This should bring some convenience like the ranges of primitive values.