### PR TITLE
Add toString implementation to date ranges

### DIFF
--- a/src/main/kotlin/me/moallemi/tools/daterange/Formatter.kt
+++ b/src/main/kotlin/me/moallemi/tools/daterange/Formatter.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Reza Moallemi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.moallemi.tools.daterange
+
+internal val defaultDateFormat: String
+    get() = isoDateFormat
+
+private const val isoDateFormat: String = "yyyy-MM-dd"

--- a/src/main/kotlin/me/moallemi/tools/daterange/date/DateRange.kt
+++ b/src/main/kotlin/me/moallemi/tools/daterange/date/DateRange.kt
@@ -16,7 +16,11 @@
 
 package me.moallemi.tools.daterange.date
 
+import java.text.SimpleDateFormat
 import java.util.Date
+import me.moallemi.tools.daterange.defaultDateFormat
+
+private val formatter = SimpleDateFormat(defaultDateFormat)
 
 class DateRange(
     override val start: Date,
@@ -27,6 +31,8 @@ class DateRange(
     override fun iterator(): Iterator<Date> = DateIterator(start, endInclusive, stepDays)
 
     infix fun step(days: Int) = DateRange(start, endInclusive, days)
+
+    override fun toString(): String = "${formatter.format(start)}..${formatter.format(endInclusive)}"
 
     companion object {
         val EMPTY: DateRange = DateRange(Date(1), Date(0))

--- a/src/main/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRange.kt
+++ b/src/main/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRange.kt
@@ -17,6 +17,10 @@
 package me.moallemi.tools.daterange.localdate
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import me.moallemi.tools.daterange.defaultDateFormat
+
+private val formatter = DateTimeFormatter.ofPattern(defaultDateFormat)
 
 class LocalDateRange(
     override val start: LocalDate,
@@ -28,6 +32,8 @@ class LocalDateRange(
         LocalDateIterator(start, endInclusive, stepDays)
 
     infix fun step(days: Long) = LocalDateRange(start, endInclusive, days)
+
+    override fun toString(): String = "${start.format(formatter)}..${endInclusive.format(formatter)}"
 
     companion object {
         val EMPTY: LocalDateRange = LocalDateRange(LocalDate.ofEpochDay(1), LocalDate.ofEpochDay(0))

--- a/src/test/kotlin/me/moallemi/tools/daterange/date/DateRangeTest.kt
+++ b/src/test/kotlin/me/moallemi/tools/daterange/date/DateRangeTest.kt
@@ -76,4 +76,17 @@ class DateRangeTest {
 
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun testToString() {
+        calendar.set(2020, 0, 1)
+        val startDate = calendar.time
+        calendar.set(2020, 0, 5)
+        val endDate = calendar.time
+
+        assertEquals(
+            "2020-01-01..2020-01-05",
+            (startDate..endDate).toString()
+        )
+    }
 }

--- a/src/test/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRangeTest.kt
+++ b/src/test/kotlin/me/moallemi/tools/daterange/localdate/LocalDateRangeTest.kt
@@ -72,4 +72,15 @@ class LocalDateRangeTest {
 
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun testToString() {
+        val startDate = LocalDate.of(2020, 1, 1)
+        val endDate = LocalDate.of(2020, 1, 5)
+
+        assertEquals(
+            "2020-01-01..2020-01-05",
+            (startDate..endDate).toString()
+        )
+    }
 }


### PR DESCRIPTION
This PR adds `toString` implementation so that when debugging you have a clear view on what range an instance of `DateRange` represents

![image](https://user-images.githubusercontent.com/15970653/112886856-c3f3d180-90d2-11eb-88b0-f778e1613f4d.png)
